### PR TITLE
add possibility to use native promise

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,8 @@
 var wrapper = require('@pact-foundation/pact-node');
-var bluebird = require("bluebird");
+var promise = Promise || require("bluebird");
 var deasync = require('deasync');
 
 var runPactMockServer = function (pacts, logger) {
-	var promise = Promise || bluebird;
 	var log = logger.create('pact');
 	pacts = pacts || [];
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,20 @@
 var wrapper = require('@pact-foundation/pact-node');
-var Promise = require("bluebird");
+var bluebird = require("bluebird");
 var deasync = require('deasync');
 
 var runPactMockServer = function (pacts, logger) {
+	var promise = Promise || bluebird;
 	var log = logger.create('pact');
 	pacts = pacts || [];
-	
+
 	// If pact options is object, wrap in array
 	if (!Array.isArray(pacts)) {
 		pacts = [pacts];
 	}
-	
+
 	var done = false;
-	
-	Promise.all(pacts.map(function (pact) {
+
+	promise.all(pacts.map(function (pact) {
 		var server = wrapper.createServer(pact);
 		return server.start().then(function () {
 			log.info('Pact Mock Server running on port: ' + server.options.port);
@@ -23,7 +24,7 @@ var runPactMockServer = function (pacts, logger) {
 	})).then(function() {
 		done = true;
 	});
-	
+
 	deasync.loopWhile(function(){return !done;});
 };
 


### PR DESCRIPTION
sometimes bluebird conflicts with other frameworks or even native promises, so it's better to just let the code use the native Promise since it's the most reliable