### PR TITLE
Updating version of deasync so npm install works for Node > V10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - 6
   - 7
   - 8
+  - 10
 os:
   - linux
   - osx

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "bluebird": "3.5.1",
-    "deasync": "0.1.12"
+    "deasync": "0.1.13"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
As per abbr/deasync#97, if the version of Node installed is > V10 then npm install fails due to an issue within Deasync itself. Deasync has been updated to the latest version which fixes this issue, but karma-pact still references the old broken version.

This PR is to update the version of Deasync used to the latest.