### PR TITLE
Widen peer dependency to include pact-node 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "http://docs.pact.io/documentation/javascript.html",
   "peerDependencies": {
     "karma": ">=1.0.0",
-    "@pact-foundation/pact-node": "^6.0.0"
+    "@pact-foundation/pact-node": "^6.0.0 || ^7.0.0" 
   },
   "dependencies": {
     "bluebird": "3.5.1",


### PR DESCRIPTION
I don't believe that the breaking change in pact-node affects this repo, so I've widened the peer dependency to accept it.